### PR TITLE
Add details to README.txt, correct FidoCadJ spelling.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,8 +5,10 @@ Syntax:
 
 $ makedeb.sh <version>
 
-where <version> will be simething like '0.24.6' or similar, so the resulting package name
-will be fidocadj-<version>.deb. In this document, we refer to it as <packagename>.
+where <version> will be something like '0.24.6' or similar, so the resulting package name
+will be fidocadj-<version>.deb. In this document, we refer to it as <packagename>. If the
+version number is followed by a greek letter, the version is considered an unstable
+preliminary version.
 
 The file fidocadj.jar with version <version> will be installed in '/usr/local/bin'.
 It's supposed that '/usr/local/bin' is already in the environment variable PATH.  
@@ -15,6 +17,6 @@ The package created from makedeb.sh can be installed (with root permissions) exe
 
 # dpkg -i <packagename> 
 
-Fidocadj is written in Java so from shell you can execute it with java:
+FidoCadJ is written in Java so from shell you can execute it with java:
 
 $ java -jar /usr/local/bin/fidocadj.jar


### PR DESCRIPTION
Correct the FidoCadJ spelling and a small typo.
Add a description of preliminary versions in the FidoCadJ naming convention.
